### PR TITLE
Timezone additions

### DIFF
--- a/src/rmDefinitionAggregation.js
+++ b/src/rmDefinitionAggregation.js
@@ -4,15 +4,15 @@ import axios from 'axios';
 const QueryURLTemplate =  "/recordm/recordm/definitions/search?"
 const ResultsURLTemplate = "#/definitions/__DEF_ID__/q=__QUERY__"
 
-const rmDefinitionAggregation = function (def, aggregation, query="*", from=0, size=10, sort="", ascending="asc") {
+const rmDefinitionAggregation = function (def, aggregation, query="*", from=0, size=10, sort="", ascending="asc", timezone="") {
   
   let queryUrl = QueryURLTemplate + (typeof def == "number" ? "defId=" : "def=") + def
-
 
   let data = {
     "query": {
       "query_string": {
         "query": query,
+        "time_zone" : timezone == "" ? undefined : timezone,
         "default_operator": "AND",
         "analyze_wildcard": true
       }

--- a/src/rmDefinitionSearch.js
+++ b/src/rmDefinitionSearch.js
@@ -1,16 +1,17 @@
 import { getServer } from "./server.js";
 import axios from 'axios';
 
-const QueryURLTemplate =  "/recordm/recordm/definitions/search/name/__DEF_NAME__?from=__FROM__&size=__SIZE__&q=__QUERY__"
+const QueryURLTemplate =  "/recordm/recordm/definitions/search/name/__DEF_NAME__?from=__FROM__&size=__SIZE__&q=__QUERY__&tz=__TIMEZONE__"
 const ResultsURLTemplate = "#/definitions/__DEF_ID__/q=__QUERY__"
 
-const rmDefinitionSearch = async function (definitionName, query="*", from=0, size=0, sort="", ascending="") {
+const rmDefinitionSearch = async function (definitionName, query="*", from=0, size=0, sort="", ascending="", tz="") {
   //TODO: verificar se o AXIOS permite especificar correctamente os query parameters 
   let queryUrl = QueryURLTemplate
     .replace('__DEF_NAME__',definitionName)
     .replace('__QUERY__',encodeURIComponent(query))
     .replace('__FROM__',from)
     .replace('__SIZE__',size)
+    .replace('__TIMEZONE__', tz)
 
   if(sort) queryUrl += "&sort="+sort
   if(ascending) queryUrl += "&ascending="+ascending

--- a/tests/rmDefinitionAdvSearch.test.js
+++ b/tests/rmDefinitionAdvSearch.test.js
@@ -6,7 +6,7 @@ test('for the learning server, "countries series" is defId 2, and count for "Ara
     rmDefinitionAggregation(2, {}, "Arab world")
     .then( result => {
         expect(result.resultsUrl).toBe("https://learning.cultofbits.com/recordm/#/definitions/2/q=Arab world")
-        expect(result.hits.total.value).toBe(20)
+        expect(result.hits.total.value).toBe(22)
         done()
     })
     .catch(e => {
@@ -18,7 +18,7 @@ test('for the learning server, "countries series" is defId 2, and count for "Ara
     rmDefinitionAggregation("Countries Series", {}, "Arab world")
     .then( result => {
         expect(result.resultsUrl).toBe("https://learning.cultofbits.com/recordm/#/definitions/2/q=Arab world")
-        expect(result.hits.total.value).toBe(20)
+        expect(result.hits.total.value).toBe(22)
         done()
     })
     .catch(e => {
@@ -26,6 +26,24 @@ test('for the learning server, "countries series" is defId 2, and count for "Ara
     })
 })
 
+
+test('Total population for all countries combined in the year 2018. The query should fail if timezone is not given, due to DLS', async (done) => {
+    let agg = {
+        "x": {
+            "sum": {
+                "field": "value"
+            }
+        }
+    }
+
+    const with_tz = await rmDefinitionAggregation("Countries Series", agg , 'year.date:2018-07-10 year.date:2018-07-10 indicator_name:"population, total"', 0, 0, "", "", "Europe/Lisbon")
+    expect(with_tz.aggregations['sum#x'].value).toBe(80494309045)
+
+    const without_tz = await rmDefinitionAggregation("Countries Series", agg , 'year.date:2018-07-10 year.date:2018-07-10 indicator_name:"population, total"')
+    expect(without_tz.aggregations['sum#x'].value).toBe(0)
+
+    done()
+})
 
 test('for "Arab world" population sum over years is 2.019.650.012', (done) => {
     let agg = {
@@ -62,8 +80,8 @@ test('for "Arab world" there are 4 indicators', (done) => {
     .then( result => {
         expect(result.resultsUrl).toBe("https://learning.cultofbits.com/recordm/#/definitions/2/q=Arab  World")
         expect(result.aggregations['sterms#x'].buckets).toEqual([
+            { doc_count: 7, key: 'GDP: linked series (current LCU)' },
             { doc_count: 5, key: 'Alternative and nuclear energy (% of total energy use)' },
-            { doc_count: 5, key: 'GDP: linked series (current LCU)' },
             { doc_count: 5, key: 'Population, total' },
             { doc_count: 5, key: 'Surface area (sq. km)' }
           ])

--- a/tests/rmDefinitionSearch.test.js
+++ b/tests/rmDefinitionSearch.test.js
@@ -6,7 +6,7 @@ import rmDefinitionSearch from "../src/rmDefinitionSearch"
 test('for the learning server, "countries series" count for "Arab world" is 20', () => {
     rmDefinitionSearch("Countries Series", "Arab world")
     .then( result => {
-        expect(result.hits.total.value).toBe(20)
+        expect(result.hits.total.value).toBe(22)
     })
 })
 
@@ -37,6 +37,18 @@ test('search for a definition that does not exist logs an error and throws "Defi
 test('for the learning server, "countries series" count for "Arab world" is 20, even when using + signs in the query' , () => {
     rmDefinitionSearch("Countries Series", "Arab world year.date:<now-100y+100y")
     .then( result => {
-        expect(result.hits.total.value).toBe(20)
+        expect(result.hits.total.value).toBe(22)
     })
+})
+
+test('for the learning server, "countries series" count for the date 2018-10-07. With timezone Europe/Lisbon it should find several matches. Without it, it will not find anything.' , async () => {
+    // Dates are stored as UTC at midnight. This means without the Europe/Lisbon 
+    // timezone, they are seen as the previous day during daylight savings 
+    // (00h00 - 1h = 23h00 prev day) and as such the query misses them.
+    const with_tz = await rmDefinitionSearch("Countries Series", "year.date:2018-07-10", 0, 0, "", "", "Europe/Lisbon")
+    expect(with_tz.hits.total.value).toBeGreaterThan(0)
+    
+    const without_tz = await rmDefinitionSearch("Countries Series", "year.date:2018-07-10")
+    expect(without_tz.hits.total.value).toBe(0)
+
 })


### PR DESCRIPTION
Added timezones to both the `rmDefinitionSearch` and `rmDefinitionAggregation` functions. Added the corresponding tests to their respective test files (`rmDefinitionSearch.test.js` and `rmDefinitionAdvSearch.test.js`). Updated tests to account for new data in Learning.