### PR TITLE
Made the machine's timezone the default (instead of nothing)

### DIFF
--- a/src/rmDefinitionAggregation.js
+++ b/src/rmDefinitionAggregation.js
@@ -5,14 +5,16 @@ const QueryURLTemplate =  "/recordm/recordm/definitions/search?"
 const ResultsURLTemplate = "#/definitions/__DEF_ID__/q=__QUERY__"
 
 const rmDefinitionAggregation = function (def, aggregation, query="*", from=0, size=10, sort="", ascending="asc", timezone) {
-  
+ 
+  let tz = timezone === null || timezone === undefined ? Intl.DateTimeFormat().resolvedOptions().timeZone : timezone
+
   let queryUrl = QueryURLTemplate + (typeof def == "number" ? "defId=" : "def=") + def
 
   let data = {
     "query": {
       "query_string": {
         "query": query,
-        "time_zone" : timezone,
+        "time_zone" : tz,
         "default_operator": "AND",
         "analyze_wildcard": true
       }

--- a/src/rmDefinitionAggregation.js
+++ b/src/rmDefinitionAggregation.js
@@ -6,7 +6,7 @@ const ResultsURLTemplate = "#/definitions/__DEF_ID__/q=__QUERY__"
 
 const rmDefinitionAggregation = function (def, aggregation, query="*", from=0, size=10, sort="", ascending="asc", timezone) {
  
-  let tz = timezone === null || timezone === undefined ? Intl.DateTimeFormat().resolvedOptions().timeZone : timezone
+  let tz = !timezone ? Intl.DateTimeFormat().resolvedOptions().timeZone : timezone
 
   let queryUrl = QueryURLTemplate + (typeof def == "number" ? "defId=" : "def=") + def
 

--- a/src/rmDefinitionSearch.js
+++ b/src/rmDefinitionSearch.js
@@ -6,7 +6,7 @@ const ResultsURLTemplate = "#/definitions/__DEF_ID__/q=__QUERY__"
 
 const rmDefinitionSearch = async function (definitionName, query="*", from=0, size=0, sort="", ascending="", timezone) {
  
-  let tz = timezone === null || timezone === undefined ? Intl.DateTimeFormat().resolvedOptions().timeZone : timezone
+  let tz = !timezone ? Intl.DateTimeFormat().resolvedOptions().timeZone : timezone
 
   //TODO: verificar se o AXIOS permite especificar correctamente os query parameters 
   let queryUrl = QueryURLTemplate

--- a/src/rmDefinitionSearch.js
+++ b/src/rmDefinitionSearch.js
@@ -5,13 +5,16 @@ const QueryURLTemplate =  "/recordm/recordm/definitions/search/name/__DEF_NAME__
 const ResultsURLTemplate = "#/definitions/__DEF_ID__/q=__QUERY__"
 
 const rmDefinitionSearch = async function (definitionName, query="*", from=0, size=0, sort="", ascending="", timezone) {
+ 
+  let tz = timezone === null || timezone === undefined ? Intl.DateTimeFormat().resolvedOptions().timeZone : timezone
+
   //TODO: verificar se o AXIOS permite especificar correctamente os query parameters 
   let queryUrl = QueryURLTemplate
     .replace('__DEF_NAME__',definitionName)
     .replace('__QUERY__',encodeURIComponent(query))
     .replace('__FROM__',from)
     .replace('__SIZE__',size)
-    .replace('__TIMEZONE__', (timezone === null || timezone === undefined) ? "" : timezone)
+    .replace('__TIMEZONE__', tz)
 
   if(sort) queryUrl += "&sort="+sort
   if(ascending) queryUrl += "&ascending="+ascending

--- a/tests/rmDefinitionAdvSearch.test.js
+++ b/tests/rmDefinitionAdvSearch.test.js
@@ -27,7 +27,9 @@ test('for the learning server, "countries series" is defId 2, and count for "Ara
 })
 
 
-test('Total population for all countries combined in the year 2018. The query should fail if timezone is not given, due to DST', async (done) => {
+test('Total population for all countries combined in the year 2018. The query should fail if given the UTC timezone (default is the machine\'s), due to DST', async (done) => {
+    // Test assumes a Europe/Lisbon machine
+    
     let agg = {
         "x": {
             "sum": {
@@ -36,10 +38,10 @@ test('Total population for all countries combined in the year 2018. The query sh
         }
     }
 
-    const with_tz = await rmDefinitionAggregation("Countries Series", agg , 'year.date:2018-07-10 indicator_name:"population, total"', 0, 0, "", "", "Europe/Lisbon")
+    const with_tz = await rmDefinitionAggregation("Countries Series", agg , 'year.date:2018-07-10 indicator_name:"population, total"')
     expect(with_tz.aggregations['sum#x'].value).toBe(80494309045)
 
-    const without_tz = await rmDefinitionAggregation("Countries Series", agg , 'year.date:2018-07-10 indicator_name:"population, total"')
+    const without_tz = await rmDefinitionAggregation("Countries Series", agg , 'year.date:2018-07-10 indicator_name:"population, total"',0, 0, "", "", "Etc/UTC")
     expect(without_tz.aggregations['sum#x'].value).toBe(0)
 
     done()

--- a/tests/rmDefinitionSearch.test.js
+++ b/tests/rmDefinitionSearch.test.js
@@ -41,14 +41,16 @@ test('for the learning server, "countries series" count for "Arab world" is 20, 
     })
 })
 
-test('for the learning server, "countries series" count for the date 2018-10-07. With timezone Europe/Lisbon it should find several matches. Without it, it will not find anything.' , async () => {
+test('for the learning server, "countries series" count for the date 2018-10-07. With timezone Europe/Lisbon it should find several matches. In UTC, it will not find anything.' , async () => {
     // Dates are stored as UTC at midnight. This means without the Europe/Lisbon 
     // timezone, they are seen as the previous day during daylight savings 
     // (00h00 - 1h = 23h00 prev day) and as such the query misses them.
-    const with_tz = await rmDefinitionSearch("Countries Series", "year.date:2018-07-10", 0, 0, "", "", "Europe/Lisbon")
+    // Test assumes a Europe/Lisbon machine
+    
+    const with_tz = await rmDefinitionSearch("Countries Series", "year.date:2018-07-10")
     expect(with_tz.hits.total.value).toBeGreaterThan(0)
     
-    const without_tz = await rmDefinitionSearch("Countries Series", "year.date:2018-07-10")
+    const without_tz = await rmDefinitionSearch("Countries Series", "year.date:2018-07-10", 0, 0, "", "", "Etc/UTC")
     expect(without_tz.hits.total.value).toBe(0)
 
 })


### PR DESCRIPTION
Uses the machine's timezone the default instead of passing an empty timezone to the query. 

My main doubt is in the test - it currently assumes that the machine is running in "Europe/Lisbon" so we can also test whether the default is being correctly assigned, but I'm not sure this is the most correct way. 